### PR TITLE
Continue object enumeration on error

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -82,7 +82,7 @@ func (c *Fetcher) fetch() *models.CFObjects {
 
 	session, err := NewSessionExt(c.config)
 	if err != nil {
-		log.Errorf("unable to initialize cloud foundry clients: %s", err)
+		log.WithError(err).Error("unable to initialize cloud foundry clients")
 		result.Error = err
 		return result
 	}


### PR DESCRIPTION
This PR fixes #85 by changing the error handling:
- fetching a non existent space summary will result in a warning instead of an error
- when an expected relationship is not found on one item, the object enumeration will continue instead of stopping. The metric `last_<type>_scrape_error` will still be incremented