### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Refer to the [contributing guidelines][contributing].
 Apache License 2.0, see [LICENSE][license].
 
 [binaries]: https://github.com/cloudfoundry/cf_exporter/releases
-[cf_api]: https://apidocs.cloudfoundry.org/
+[cf_api_v2]: https://v2-apidocs.cloudfoundry.org/
 [cf_api_v3]: https://v3-apidocs.cloudfoundry.org/
 [cloudfoundry]: https://www.cloudfoundry.org/
 [contributing]: ./CONTRIBUTING.md


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)