### PR TITLE
Fix linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,9 @@ linters:
   disable-all: false
   enable:
   - bodyclose
+  - copyloopvar
   - dogsled
   - errcheck
-  - exportloopref
   - gocognit
   - goconst
   - gocritic

--- a/fetcher/worker.go
+++ b/fetcher/worker.go
@@ -41,8 +41,8 @@ func (c *Worker) Push(name string, handler WorkHandler) {
 	}
 }
 
-func (c *Worker) PushIf(name string, handler WorkHandler, any ...string) {
-	if c.filter.Any(any...) {
+func (c *Worker) PushIf(name string, handler WorkHandler, anyArgs ...string) {
+	if c.filter.Any(anyArgs...) {
 		c.Push(name, handler)
 	}
 }


### PR DESCRIPTION
Fixing 

```
fetcher/worker.go:44:59: redefines-builtin-id: redefinition of the built-in type any (revive)
func (c *Worker) PushIf(name string, handler WorkHandler, any ...string) {
```

and 

`WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.`