### PR TITLE
Ensure BBS metrics only get disabled for current run

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -41,11 +41,12 @@ type Fetcher struct {
 }
 
 func NewFetcher(threads int, config *CFConfig, bbsConfig *BBSConfig, filter *filters.Filter) *Fetcher {
+	clonedFilter := filter.Clone()
 	return &Fetcher{
 		cfConfig:  config,
 		bbsConfig: bbsConfig,
-		filters:   filter.Clone(),
-		worker:    NewWorker(threads, filter),
+		filters:   clonedFilter,
+		worker:    NewWorker(threads, clonedFilter),
 	}
 }
 

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -44,7 +44,7 @@ func NewFetcher(threads int, config *CFConfig, bbsConfig *BBSConfig, filter *fil
 	return &Fetcher{
 		cfConfig:  config,
 		bbsConfig: bbsConfig,
-		filters:   filter,
+		filters:   filter.Clone(),
 		worker:    NewWorker(threads, filter),
 	}
 }

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -1,8 +1,16 @@
 package fetcher
 
 import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"code.cloudfoundry.org/cli/v8/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/v8/resources"
+	"github.com/cloudfoundry/cf_exporter/v2/models"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 
 	"github.com/cloudfoundry/cf_exporter/v2/filters"
 )
@@ -249,5 +257,98 @@ var _ = ginkgo.Describe("Fetcher", func() {
 			})
 		})
 
+	})
+
+	ginkgo.Context("disabling filters during a scrape", func() {
+		ginkgo.It("does not mutate the original filter used for future scrapes", func() {
+			filter, err := filters.NewFilter()
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+
+			fetcher := NewFetcher(10, &CFConfig{}, &BBSConfig{}, filter)
+			fetcher.filters.Disable([]string{filters.ActualLRPs})
+
+			gomega.Ω(fetcher.filters.Enabled(filters.ActualLRPs)).Should(gomega.BeFalse())
+			gomega.Ω(filter.Enabled(filters.ActualLRPs)).Should(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.Context("when BBS client initialization fails", func() {
+		var server *ghttp.Server
+
+		ginkgo.BeforeEach(func() {
+			tokenResponse := fmt.Sprintf(`{"access_token": "%s", "refresh_token": "value"}`, fakeToken)
+			server = ghttp.NewServer()
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/"),
+					ghttp.RespondWith(http.StatusOK, serialize(ccv3.Root{
+						Links: ccv3.RootLinks{
+							Login: resources.APILink{HREF: server.URL()},
+							UAA:   resources.APILink{HREF: server.URL()},
+						},
+					})),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/oauth/token"),
+					ghttp.RespondWith(http.StatusOK, tokenResponse),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/oauth/token"),
+					ghttp.RespondWith(http.StatusOK, tokenResponse),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/oauth/token"),
+					ghttp.RespondWith(http.StatusOK, tokenResponse),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/v3/info"),
+					ghttp.RespondWith(http.StatusOK, serialize(models.Info{Name: "test-foundation"})),
+				),
+			)
+		})
+
+		ginkgo.AfterEach(func() {
+			server.Close()
+		})
+
+		ginkgo.It("disables actual lrps only for the current scrape", func() {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			refusedURL := fmt.Sprintf("http://%s", listener.Addr().String())
+			gomega.Ω(listener.Close()).Should(gomega.Succeed())
+
+			filter, err := filters.NewFilter(filters.ActualLRPs)
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+
+			fetcher := NewFetcher(1, &CFConfig{
+				URL:          server.URL(),
+				ClientID:     "fake",
+				ClientSecret: "fake",
+			}, &BBSConfig{
+				URL:     refusedURL,
+				Timeout: 1,
+			}, filter)
+
+			objs := fetcher.GetObjects()
+
+			gomega.Ω(objs.Error).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(objs.Info.Name).Should(gomega.Equal("test-foundation"))
+			gomega.Ω(objs.ProcessActualLRPs).Should(gomega.BeEmpty())
+			gomega.Ω(fetcher.filters.Enabled(filters.ActualLRPs)).Should(gomega.BeFalse())
+			gomega.Ω(filter.Enabled(filters.ActualLRPs)).Should(gomega.BeTrue())
+		})
 	})
 })

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -53,6 +53,18 @@ type Filter struct {
 	activated map[string]bool
 }
 
+func (f *Filter) Clone() *Filter {
+	clone := &Filter{
+		activated: make(map[string]bool, len(f.activated)),
+	}
+
+	for name, active := range f.activated {
+		clone.activated[name] = active
+	}
+
+	return clone
+}
+
 func NewFilter(active ...string) (*Filter, error) {
 	filter := &Filter{
 		activated: map[string]bool{


### PR DESCRIPTION
Beginning of every scrape the connection to BBS gets established freshly, but if something during that connection establishing goes wrong, the filter what metrics to fetch get adjusted to not fetch bbs related metrics anymore. 
That means, as of now, we test every scrape that we can connect to BBS, but when that fails one time, we never fetch metrics again, even if the connection can be established again.

This PR should fix that, and only disable fetching the BBS related metrics for the specific scrape run.