### PR TITLE
Add renovate.json + workflow that regularly bumps github actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,19 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # weekly
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v41
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GIT_AUTHOR: "cf-prometheus-ci-bot <184612680+cf-prometheus-ci-bot@users.noreply.github.com>"
+          RENOVATE_TOKEN: ${{ secrets.CF_PROM_CI_BOT_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "pinDigests": true,
+      "schedule": ["before 6am on monday"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a renovate.json + a cronjob renovate task to ensure we frequently bump the github actions we use